### PR TITLE
feat(agent): ensure return_direct tools still query llm once

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -417,6 +417,57 @@ class BaseWorkflowAgent(
 
         memory: BaseMemory = await ctx.store.get("memory")
 
+        if await ctx.store.get("pending_return_direct", default=False):
+            # A tool requested a direct return; run one final LLM pass and
+            # stop regardless of any further tool calls.
+            await ctx.store.set("pending_return_direct", False)
+            output = await self.finalize(ctx, ev, memory)
+            messages = await memory.aget()
+            cur_tool_calls: List[ToolCallResult] = await ctx.store.get(
+                "current_tool_calls", default=[]
+            )
+            output.tool_calls.extend(cur_tool_calls)  # type: ignore
+
+            if self.structured_output_fn is not None:
+                try:
+                    if inspect.iscoroutinefunction(self.structured_output_fn):
+                        output.structured_response = await self.structured_output_fn(
+                            messages
+                        )
+                    else:
+                        output.structured_response = cast(
+                            Dict[str, Any], self.structured_output_fn(messages)
+                        )
+                    ctx.write_event_to_stream(
+                        AgentStreamStructuredOutput(output=output.structured_response)
+                    )
+                except Exception as e:
+                    warnings.warn(
+                        f"There was a problem with the generation of the structured output: {e}"
+                    )
+            if self.output_cls is not None:
+                try:
+                    llm_input = [*messages]
+                    if self.system_prompt:
+                        llm_input = [
+                            ChatMessage(role="system", content=self.system_prompt),
+                            *llm_input,
+                        ]
+                    output.structured_response = await generate_structured_response(
+                        messages=llm_input, llm=self.llm, output_cls=self.output_cls
+                    )
+                    ctx.write_event_to_stream(
+                        AgentStreamStructuredOutput(output=output.structured_response)
+                    )
+                except Exception as e:
+                    warnings.warn(
+                        f"There was a problem with the generation of the structured output: {e}"
+                    )
+
+            await ctx.store.set("current_tool_calls", [])
+
+            return StopEvent(result=output)
+
         if ev.retry_messages:
             # Retry with the given messages to let the LLM fix potential errors
             history = await memory.aget()
@@ -560,7 +611,8 @@ class BaseWorkflowAgent(
             tool_call_result.return_direct and not tool_call_result.tool_output.is_error
             for tool_call_result in tool_call_results
         ):
-            # if any tool calls return directly and it's not an error tool call, take the first one
+            # if any tool calls request a direct return and it's not an error
+            # tool call, take the first one
             return_direct_tool = next(
                 tool_call_result
                 for tool_call_result in tool_call_results
@@ -568,28 +620,30 @@ class BaseWorkflowAgent(
                 and not tool_call_result.tool_output.is_error
             )
 
-            # always finalize the agent, even if we're just handing off
-            result = AgentOutput(
-                response=ChatMessage(
-                    role="assistant",
-                    content=return_direct_tool.tool_output.content or "",
-                ),
-                tool_calls=[
-                    ToolSelection(
-                        tool_id=t.tool_id,
-                        tool_name=t.tool_name,
-                        tool_kwargs=t.tool_kwargs,
-                    )
-                    for t in cur_tool_calls
-                ],
-                raw=return_direct_tool.tool_output.raw_output,
-                current_agent_name=self.name,
-            )
-            result = await self.finalize(ctx, result, memory)
-            # we don't want to stop the system if we're just handing off
-            if return_direct_tool.tool_name != "handoff":
-                await ctx.store.set("current_tool_calls", [])
-                return StopEvent(result=result)
+            if return_direct_tool.tool_name == "handoff":
+                # For handoff tools we immediately finalize and allow the
+                # workflow to continue without an additional LLM pass.
+                result = AgentOutput(
+                    response=ChatMessage(
+                        role="assistant",
+                        content=return_direct_tool.tool_output.content or "",
+                    ),
+                    tool_calls=[
+                        ToolSelection(
+                            tool_id=t.tool_id,
+                            tool_name=t.tool_name,
+                            tool_kwargs=t.tool_kwargs,
+                        )
+                        for t in cur_tool_calls
+                    ],
+                    raw=return_direct_tool.tool_output.raw_output,
+                    current_agent_name=self.name,
+                )
+                await self.finalize(ctx, result, memory)
+            else:
+                # Mark that we should stop after the next LLM call which will
+                # generate the final response based on the tool output.
+                await ctx.store.set("pending_return_direct", True)
 
         user_msg_str = await ctx.store.get("user_msg_str")
         input_messages = await memory.aget(input=user_msg_str)

--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -428,6 +428,10 @@ class BaseWorkflowAgent(
             )
             output.tool_calls.extend(cur_tool_calls)  # type: ignore
 
+            # Emit the finalized output so downstream consumers receive the
+            # complete response before we stop the workflow.
+            ctx.write_event_to_stream(output)
+
             if self.structured_output_fn is not None:
                 try:
                     if inspect.iscoroutinefunction(self.structured_output_fn):
@@ -490,6 +494,10 @@ class BaseWorkflowAgent(
                 "current_tool_calls", default=[]
             )
             output.tool_calls.extend(cur_tool_calls)  # type: ignore
+
+            # Emit the finalized output so downstream consumers receive the
+            # complete response before we stop the workflow.
+            ctx.write_event_to_stream(output)
 
             if self.structured_output_fn is not None:
                 try:

--- a/llama-index-core/llama_index/core/agent/workflow/function_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/function_agent.py
@@ -164,13 +164,9 @@ class FunctionAgent(BaseWorkflowAgent):
                 tool_call_result.return_direct
                 and tool_call_result.tool_name != "handoff"
             ):
-                scratchpad.append(
-                    ChatMessage(
-                        role="assistant",
-                        content=str(tool_call_result.tool_output.content),
-                        additional_kwargs={"tool_call_id": tool_call_result.tool_id},
-                    )
-                )
+                # When a tool requests a direct return we short-circuit
+                # further tool result processing, but we defer final
+                # response generation to the LLM for one final pass.
                 break
 
         await ctx.store.set(self.scratchpad_key, scratchpad)

--- a/llama-index-core/tests/agent/workflow/test_function_call.py
+++ b/llama-index-core/tests/agent/workflow/test_function_call.py
@@ -65,12 +65,13 @@ def test_agent():
 
 
 @pytest.mark.asyncio
-async def test_aggregate_tool_results_return_direct_non_handoff_no_error_stops(
+async def test_aggregate_tool_results_return_direct_non_handoff_sets_flag(
     mock_context, mock_memory, test_agent
 ):
     """
-    Test that when return_direct tool is NOT 'handoff' and has NO error,
-    the workflow stops execution by returning StopEvent (lines 564-569)
+    When a non-handoff return_direct tool succeeds the workflow should not
+    stop immediately. Instead, a flag is set so that execution halts after the
+    next LLM pass.
     """
     # Arrange
     tool_output = ToolOutput(
@@ -104,13 +105,14 @@ async def test_aggregate_tool_results_return_direct_non_handoff_no_error_stops(
     result = await test_agent.aggregate_tool_results(mock_context, return_direct_tool)
 
     # Assert
-    # The method should return StopEvent when condition is met
-    assert isinstance(result, StopEvent)
-    assert result.result is not None
-    assert result.result.current_agent_name == "test_agent"
-
-    # Verify that current_tool_calls was cleared (line 567)
-    mock_context.store.set.assert_any_call("current_tool_calls", [])
+    assert isinstance(result, AgentInput)
+    mock_context.store.set.assert_any_call("pending_return_direct", True)
+    calls_to_clear = [
+        call
+        for call in mock_context.store.set.call_args_list
+        if call[0][0] == "current_tool_calls" and call[0][1] == []
+    ]
+    assert len(calls_to_clear) == 0
 
 
 @pytest.mark.asyncio
@@ -275,7 +277,8 @@ async def test_aggregate_tool_results_context_store_operations_for_successful_re
     mock_context, mock_memory, test_agent
 ):
     """
-    Test that context store operations are performed correctly when condition is met (lines 567-568)
+    Test that context store operations are performed correctly when a non-handoff
+    return_direct tool succeeds.
     """
     # Arrange
     tool_output = ToolOutput(
@@ -310,16 +313,14 @@ async def test_aggregate_tool_results_context_store_operations_for_successful_re
     result = await test_agent.aggregate_tool_results(mock_context, success_tool)
 
     # Assert
-    # Verify StopEvent was returned
-    assert isinstance(result, StopEvent)
-    assert result.result is not None
-
-    # Verify context store was called correctly (line 567)
-    mock_context.store.set.assert_any_call("current_tool_calls", [])
-
-    # Verify the result contains the correct information
-    assert result.result.current_agent_name == "test_agent"
-    assert result.result.response.content == "Success"
+    assert isinstance(result, AgentInput)
+    mock_context.store.set.assert_any_call("pending_return_direct", True)
+    calls_to_clear = [
+        call
+        for call in mock_context.store.set.call_args_list
+        if call[0][0] == "current_tool_calls" and call[0][1] == []
+    ]
+    assert len(calls_to_clear) == 0
 
 
 @pytest.mark.asyncio
@@ -380,11 +381,14 @@ async def test_aggregate_tool_results_multiple_tools_one_return_direct_eligible(
     result = await test_agent.aggregate_tool_results(mock_context, success_tool)
 
     # Assert
-    # Should return StopEvent because one tool is eligible
-    assert isinstance(result, StopEvent)
-
-    # Verify context store was called to clear current_tool_calls (line 567)
-    mock_context.store.set.assert_any_call("current_tool_calls", [])
+    assert isinstance(result, AgentInput)
+    mock_context.store.set.assert_any_call("pending_return_direct", True)
+    calls_to_clear = [
+        call
+        for call in mock_context.store.set.call_args_list
+        if call[0][0] == "current_tool_calls" and call[0][1] == []
+    ]
+    assert len(calls_to_clear) == 0
 
 
 @pytest.mark.asyncio

--- a/llama-index-core/tests/agent/workflow/test_return_direct_llm_pass.py
+++ b/llama-index-core/tests/agent/workflow/test_return_direct_llm_pass.py
@@ -1,0 +1,67 @@
+import pytest
+from typing import Any, List
+
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.core.base.llms.types import ChatMessage, ChatResponse, LLMMetadata
+from llama_index.core.llms import MockLLM
+from llama_index.core.llms.llm import ToolSelection
+from llama_index.core.tools import FunctionTool
+from llama_index.core.workflow import Context
+
+
+class CountingLLM(MockLLM):
+    calls: int = 0
+
+    @property
+    def metadata(self) -> LLMMetadata:
+        return LLMMetadata(is_function_calling_model=True)
+
+    async def achat_with_tools(
+        self, chat_history: List[ChatMessage], tools: List[Any], **kwargs: Any
+    ) -> ChatResponse:
+        self.calls += 1
+        if self.calls == 1:
+            message = ChatMessage(
+                role="assistant",
+                content=None,
+                additional_kwargs={
+                    "tool_calls": [
+                        ToolSelection(
+                            tool_id="tool_1",
+                            tool_name="direct_tool",
+                            tool_kwargs={},
+                        )
+                    ]
+                },
+            )
+        else:
+            message = ChatMessage(role="assistant", content="final answer from llm")
+        return ChatResponse(message=message, raw={})
+
+    def get_tool_calls_from_response(
+        self, response: ChatResponse, **kwargs: Any
+    ) -> List[ToolSelection]:
+        return response.message.additional_kwargs.get("tool_calls", [])
+
+
+async def direct_tool() -> str:
+    return "tool output"
+
+
+@pytest.mark.asyncio
+async def test_return_direct_triggers_final_llm_pass() -> None:
+    llm = CountingLLM()
+    agent = FunctionAgent(
+        name="test_agent",
+        description="test",
+        tools=[FunctionTool.from_defaults(fn=direct_tool, return_direct=True)],
+        llm=llm,
+        streaming=False,
+    )
+    ctx = Context(agent)
+    handler = agent.run("call the tool", ctx=ctx)
+    async for _ in handler.stream_events():
+        pass
+    result = await handler
+    assert result.response.content == "final answer from llm"
+    assert llm.calls == 2

--- a/llama-index-core/tests/agent/workflow/test_return_direct_llm_pass.py
+++ b/llama-index-core/tests/agent/workflow/test_return_direct_llm_pass.py
@@ -7,6 +7,7 @@ from llama_index.core.llms import MockLLM
 from llama_index.core.llms.llm import ToolSelection
 from llama_index.core.tools import FunctionTool
 from llama_index.core.workflow import Context
+from llama_index.core.agent.workflow.workflow_events import AgentStream
 
 
 class CountingLLM(MockLLM):
@@ -65,3 +66,81 @@ async def test_return_direct_triggers_final_llm_pass() -> None:
     result = await handler
     assert result.response.content == "final answer from llm"
     assert llm.calls == 2
+
+
+class CountingStreamingLLM(MockLLM):
+    calls: int = 0
+
+    @property
+    def metadata(self) -> LLMMetadata:
+        return LLMMetadata(is_function_calling_model=True)
+
+    async def astream_chat_with_tools(
+        self, chat_history: List[ChatMessage], tools: List[Any], **kwargs: Any
+    ):
+        self.calls += 1
+
+        async def gen():
+            if self.calls == 1:
+                message = ChatMessage(
+                    role="assistant",
+                    content=None,
+                    additional_kwargs={
+                        "tool_calls": [
+                            ToolSelection(
+                                tool_id="tool_1",
+                                tool_name="direct_tool",
+                                tool_kwargs={},
+                            )
+                        ]
+                    },
+                )
+                yield ChatResponse(message=message, raw={})
+            else:
+                yield ChatResponse(
+                    message=ChatMessage(
+                        role="assistant", content="final", additional_kwargs={}
+                    ),
+                    raw={},
+                    delta="final",
+                )
+                yield ChatResponse(
+                    message=ChatMessage(
+                        role="assistant",
+                        content="final answer from llm",
+                        additional_kwargs={},
+                    ),
+                    raw={},
+                    delta=" answer from llm",
+                )
+
+        return gen()
+
+    def get_tool_calls_from_response(
+        self, response: ChatResponse, **kwargs: Any
+    ) -> List[ToolSelection]:
+        return response.message.additional_kwargs.get("tool_calls", [])
+
+
+@pytest.mark.asyncio
+async def test_return_direct_streams_final_llm_pass() -> None:
+    llm = CountingStreamingLLM()
+    agent = FunctionAgent(
+        name="test_agent",
+        description="test",
+        tools=[FunctionTool.from_defaults(fn=direct_tool, return_direct=True)],
+        llm=llm,
+        streaming=True,
+    )
+    ctx = Context(agent)
+    handler = agent.run("call the tool", ctx=ctx)
+
+    streamed = ""
+    async for ev in handler.stream_events():
+        if isinstance(ev, AgentStream):
+            streamed += ev.delta or ""
+
+    result = await handler
+    assert result.response.content == "final answer from llm"
+    assert llm.calls == 2
+    assert streamed == "final answer from llm"


### PR DESCRIPTION
## Summary
- run the LLM one final time when a tool sets `return_direct`
- skip direct answer injection into scratchpad so the LLM can craft the final message
- add regression test for return_direct LLM pass

## Testing
- `pytest llama-index-core/tests/agent/workflow/test_function_call.py llama-index-core/tests/agent/workflow/test_return_direct_llm_pass.py -q`
- `pre-commit run --files llama-index-core/llama_index/core/agent/workflow/function_agent.py llama-index-core/llama_index/core/agent/workflow/base_agent.py llama-index-core/tests/agent/workflow/test_function_call.py llama-index-core/tests/agent/workflow/test_return_direct_llm_pass.py`

------
https://chatgpt.com/codex/tasks/task_e_68bbd0cc811c832ba8b8982066778eb5