### PR TITLE
Refine return_direct to run final LLM pass

### DIFF
--- a/docs/docs/module_guides/deploying/agents/tools.md
+++ b/docs/docs/module_guides/deploying/agents/tools.md
@@ -162,7 +162,7 @@ agent = FunctionAgent(
 
 ### Return Direct
 
-You'll notice the option `return_direct` in the tool class constructor. If this is set to `True`, the response from an agent is returned directly, without being interpreted and rewritten by the agent. This can be helpful for decreasing runtime, or designing/specifying tools that will end the agent reasoning loop.
+You'll notice the option `return_direct` in the tool class constructor. If this is set to `True`, the agent will perform one final LLM pass using the tool's output before ending the reasoning loop. This allows light post-processing while still short-circuiting additional tool calls.
 
 For example, say you specify a tool:
 
@@ -179,9 +179,9 @@ agent = FunctionAgent(llm=llm, tools=[tool])
 response = await agent.run("<question that invokes tool>")
 ```
 
-In the above example, the query engine tool would be invoked, and the response from that tool would be directly returned as the response, and the execution loop would end.
+In the above example, the query engine tool would be invoked, its result passed back through the LLM once, and the final response returned before the execution loop ends.
 
-If `return_direct=False` was used, then the agent would rewrite the response using the context of the chat history, or even make another tool call.
+If `return_direct=False` was used, then the agent might rewrite the response using the context of the chat history or even make another tool call.
 
 We have also provided an [example notebook](../../../examples/agent/return_direct_agent.ipynb) of using `return_direct`.
 

--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -417,6 +417,13 @@ class BaseWorkflowAgent(
 
         memory: BaseMemory = await ctx.store.get("memory")
 
+        return_direct_pending = await ctx.store.get(
+            "return_direct_pending", default=False
+        )
+        if return_direct_pending:
+            await ctx.store.set("return_direct_pending", False)
+            ev.tool_calls = []
+
         if ev.retry_messages:
             # Retry with the given messages to let the LLM fix potential errors
             history = await memory.aget()
@@ -557,39 +564,12 @@ class BaseWorkflowAgent(
         await self.handle_tool_call_results(ctx, tool_call_results, memory)
 
         if any(
-            tool_call_result.return_direct and not tool_call_result.tool_output.is_error
+            tool_call_result.return_direct
+            and tool_call_result.tool_name != "handoff"
+            and not tool_call_result.tool_output.is_error
             for tool_call_result in tool_call_results
         ):
-            # if any tool calls return directly and it's not an error tool call, take the first one
-            return_direct_tool = next(
-                tool_call_result
-                for tool_call_result in tool_call_results
-                if tool_call_result.return_direct
-                and not tool_call_result.tool_output.is_error
-            )
-
-            # always finalize the agent, even if we're just handing off
-            result = AgentOutput(
-                response=ChatMessage(
-                    role="assistant",
-                    content=return_direct_tool.tool_output.content or "",
-                ),
-                tool_calls=[
-                    ToolSelection(
-                        tool_id=t.tool_id,
-                        tool_name=t.tool_name,
-                        tool_kwargs=t.tool_kwargs,
-                    )
-                    for t in cur_tool_calls
-                ],
-                raw=return_direct_tool.tool_output.raw_output,
-                current_agent_name=self.name,
-            )
-            result = await self.finalize(ctx, result, memory)
-            # we don't want to stop the system if we're just handing off
-            if return_direct_tool.tool_name != "handoff":
-                await ctx.store.set("current_tool_calls", [])
-                return StopEvent(result=result)
+            await ctx.store.set("return_direct_pending", True)
 
         user_msg_str = await ctx.store.get("user_msg_str")
         input_messages = await memory.aget(input=user_msg_str)

--- a/llama-index-core/llama_index/core/agent/workflow/function_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/function_agent.py
@@ -164,13 +164,6 @@ class FunctionAgent(BaseWorkflowAgent):
                 tool_call_result.return_direct
                 and tool_call_result.tool_name != "handoff"
             ):
-                scratchpad.append(
-                    ChatMessage(
-                        role="assistant",
-                        content=str(tool_call_result.tool_output.content),
-                        additional_kwargs={"tool_call_id": tool_call_result.tool_id},
-                    )
-                )
                 break
 
         await ctx.store.set(self.scratchpad_key, scratchpad)

--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -330,6 +330,13 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
         # Add messages to memory
         memory: BaseMemory = await ctx.store.get("memory")
 
+        return_direct_pending = await ctx.store.get(
+            "return_direct_pending", default=False
+        )
+        if return_direct_pending:
+            await ctx.store.set("return_direct_pending", False)
+            ev.tool_calls = []
+
         # First set chat history if it exists
         if chat_history:
             await memory.aset(chat_history)
@@ -436,6 +443,13 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
             )
 
         memory: BaseMemory = await ctx.store.get("memory")
+
+        return_direct_pending = await ctx.store.get(
+            "return_direct_pending", default=False
+        )
+        if return_direct_pending:
+            await ctx.store.set("return_direct_pending", False)
+            ev.tool_calls = []
 
         if ev.retry_messages:
             # Retry with the given messages to let the LLM fix potential errors
@@ -589,41 +603,36 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
             await ctx.store.set("current_agent_name", next_agent_name)
             await ctx.store.set("next_agent", None)
 
-        if any(
-            tool_call_result.return_direct and not tool_call_result.tool_output.is_error
-            for tool_call_result in tool_call_results
-        ):
-            # if any tool calls return directly and it's not an error tool call, take the first one
-            return_direct_tool = next(
-                tool_call_result
-                for tool_call_result in tool_call_results
-                if tool_call_result.return_direct
-                and not tool_call_result.tool_output.is_error
-            )
-
-            # always finalize the agent, even if we're just handing off
-            result = AgentOutput(
-                response=ChatMessage(
-                    role="assistant",
-                    content=return_direct_tool.tool_output.content or "",
-                ),
-                tool_calls=[
-                    ToolSelection(
-                        tool_id=t.tool_id,
-                        tool_name=t.tool_name,
-                        tool_kwargs=t.tool_kwargs,
-                    )
-                    for t in cur_tool_calls
-                ],
-                raw=return_direct_tool.tool_output.raw_output,
-                current_agent_name=agent.name,
-            )
-            result = await agent.finalize(ctx, result, memory)
-
-            # we don't want to stop the system if we're just handing off
-            if return_direct_tool.tool_name != "handoff":
-                await ctx.store.set("current_tool_calls", [])
-                return StopEvent(result=result)
+        return_direct_tool = next(
+            (
+                t
+                for t in tool_call_results
+                if t.return_direct
+                and not t.tool_output.is_error
+            ),
+            None,
+        )
+        if return_direct_tool is not None:
+            if return_direct_tool.tool_name == "handoff":
+                result = AgentOutput(
+                    response=ChatMessage(
+                        role="assistant",
+                        content=return_direct_tool.tool_output.content or "",
+                    ),
+                    tool_calls=[
+                        ToolSelection(
+                            tool_id=t.tool_id,
+                            tool_name=t.tool_name,
+                            tool_kwargs=t.tool_kwargs,
+                        )
+                        for t in cur_tool_calls
+                    ],
+                    raw=return_direct_tool.tool_output.raw_output,
+                    current_agent_name=agent.name,
+                )
+                await agent.finalize(ctx, result, memory)
+            else:
+                await ctx.store.set("return_direct_pending", True)
 
         user_msg_str = await ctx.store.get("user_msg_str")
         input_messages = await memory.aget(input=user_msg_str)

--- a/llama-index-core/tests/agent/workflow/test_function_call.py
+++ b/llama-index-core/tests/agent/workflow/test_function_call.py
@@ -65,12 +65,12 @@ def test_agent():
 
 
 @pytest.mark.asyncio
-async def test_aggregate_tool_results_return_direct_non_handoff_no_error_stops(
+async def test_aggregate_tool_results_return_direct_non_handoff_no_error_triggers_flag(
     mock_context, mock_memory, test_agent
 ):
     """
     Test that when return_direct tool is NOT 'handoff' and has NO error,
-    the workflow stops execution by returning StopEvent (lines 564-569)
+    the workflow performs an additional LLM pass by setting a flag.
     """
     # Arrange
     tool_output = ToolOutput(
@@ -104,13 +104,15 @@ async def test_aggregate_tool_results_return_direct_non_handoff_no_error_stops(
     result = await test_agent.aggregate_tool_results(mock_context, return_direct_tool)
 
     # Assert
-    # The method should return StopEvent when condition is met
-    assert isinstance(result, StopEvent)
-    assert result.result is not None
-    assert result.result.current_agent_name == "test_agent"
-
-    # Verify that current_tool_calls was cleared (line 567)
-    mock_context.store.set.assert_any_call("current_tool_calls", [])
+    # The method should return AgentInput and set the return_direct flag
+    assert isinstance(result, AgentInput)
+    mock_context.store.set.assert_any_call("return_direct_pending", True)
+    calls_to_clear = [
+        call
+        for call in mock_context.store.set.call_args_list
+        if call[0][0] == "current_tool_calls" and call[0][1] == []
+    ]
+    assert len(calls_to_clear) == 0
 
 
 @pytest.mark.asyncio
@@ -119,7 +121,7 @@ async def test_aggregate_tool_results_return_direct_handoff_does_not_stop(
 ):
     """
     Test that when return_direct tool is 'handoff',
-    the workflow does NOT stop execution (condition fails at line 564)
+    the workflow continues without setting the return_direct flag.
     """
     # Arrange
     tool_output = ToolOutput(
@@ -158,14 +160,18 @@ async def test_aggregate_tool_results_return_direct_handoff_does_not_stop(
     # Should return AgentInput to continue the workflow
     assert isinstance(result, AgentInput)
 
-    # Verify that current_tool_calls was NOT cleared specifically for the return_direct condition
-    # Note: current_tool_calls might be set for other reasons, but not the lines 564-569 condition
+    # Verify that return_direct flag was not set and current_tool_calls not cleared
+    calls_to_flag = [
+        call
+        for call in mock_context.store.set.call_args_list
+        if call[0] == ("return_direct_pending", True)
+    ]
+    assert len(calls_to_flag) == 0
     calls_to_current_tool_calls = [
         call
         for call in mock_context.store.set.call_args_list
         if call[0][0] == "current_tool_calls" and call[0][1] == []
     ]
-    # Should not find the specific call that clears current_tool_calls due to lines 564-569
     assert len(calls_to_current_tool_calls) == 0
 
 
@@ -175,7 +181,7 @@ async def test_aggregate_tool_results_return_direct_with_error_does_not_stop(
 ):
     """
     Test that when return_direct tool has an error,
-    the workflow does NOT stop execution (condition fails at line 565)
+    the workflow continues and does not set the return_direct flag.
     """
     # Arrange
     tool_output = ToolOutput(
@@ -214,13 +220,18 @@ async def test_aggregate_tool_results_return_direct_with_error_does_not_stop(
     # Should return AgentInput to continue the workflow
     assert isinstance(result, AgentInput)
 
-    # Verify that current_tool_calls was NOT cleared specifically for the return_direct condition
+    # Verify that return_direct flag was not set and current_tool_calls not cleared
+    calls_to_flag = [
+        call
+        for call in mock_context.store.set.call_args_list
+        if call[0] == ("return_direct_pending", True)
+    ]
+    assert len(calls_to_flag) == 0
     calls_to_current_tool_calls = [
         call
         for call in mock_context.store.set.call_args_list
         if call[0][0] == "current_tool_calls" and call[0][1] == []
     ]
-    # Should not find the specific call that clears current_tool_calls due to lines 564-569
     assert len(calls_to_current_tool_calls) == 0
 
 
@@ -229,8 +240,8 @@ async def test_aggregate_tool_results_return_direct_handoff_with_error_does_not_
     mock_context, mock_memory, test_agent
 ):
     """
-    Test that when return_direct tool is 'handoff' AND has an error,
-    the workflow does NOT stop execution (condition fails on both counts)
+    Test that when return_direct tool is 'handoff' and has an error,
+    the workflow continues and does not set the return_direct flag.
     """
     # Arrange
     tool_output = ToolOutput(
@@ -269,13 +280,21 @@ async def test_aggregate_tool_results_return_direct_handoff_with_error_does_not_
     # Should return AgentInput to continue the workflow
     assert isinstance(result, AgentInput)
 
+    # Verify that return_direct flag was not set
+    calls_to_flag = [
+        call
+        for call in mock_context.store.set.call_args_list
+        if call[0] == ("return_direct_pending", True)
+    ]
+    assert len(calls_to_flag) == 0
+
 
 @pytest.mark.asyncio
 async def test_aggregate_tool_results_context_store_operations_for_successful_return_direct(
     mock_context, mock_memory, test_agent
 ):
     """
-    Test that context store operations are performed correctly when condition is met (lines 567-568)
+    Test that context store operations are performed correctly when return_direct flag is set.
     """
     # Arrange
     tool_output = ToolOutput(
@@ -310,16 +329,14 @@ async def test_aggregate_tool_results_context_store_operations_for_successful_re
     result = await test_agent.aggregate_tool_results(mock_context, success_tool)
 
     # Assert
-    # Verify StopEvent was returned
-    assert isinstance(result, StopEvent)
-    assert result.result is not None
-
-    # Verify context store was called correctly (line 567)
-    mock_context.store.set.assert_any_call("current_tool_calls", [])
-
-    # Verify the result contains the correct information
-    assert result.result.current_agent_name == "test_agent"
-    assert result.result.response.content == "Success"
+    assert isinstance(result, AgentInput)
+    mock_context.store.set.assert_any_call("return_direct_pending", True)
+    calls_to_clear = [
+        call
+        for call in mock_context.store.set.call_args_list
+        if call[0][0] == "current_tool_calls" and call[0][1] == []
+    ]
+    assert len(calls_to_clear) == 0
 
 
 @pytest.mark.asyncio
@@ -327,8 +344,8 @@ async def test_aggregate_tool_results_multiple_tools_one_return_direct_eligible(
     mock_context, mock_memory, test_agent
 ):
     """
-    Test that when multiple tools are called but only one is eligible for return_direct stop,
-    the workflow stops correctly
+    Test that when multiple tools are called but only one is eligible for return_direct,
+    the workflow triggers the return_direct flag.
     """
     # Arrange
     # First tool - return_direct but is handoff (should not stop)
@@ -380,11 +397,15 @@ async def test_aggregate_tool_results_multiple_tools_one_return_direct_eligible(
     result = await test_agent.aggregate_tool_results(mock_context, success_tool)
 
     # Assert
-    # Should return StopEvent because one tool is eligible
-    assert isinstance(result, StopEvent)
-
-    # Verify context store was called to clear current_tool_calls (line 567)
-    mock_context.store.set.assert_any_call("current_tool_calls", [])
+    # Should return AgentInput and set the flag because one tool is eligible
+    assert isinstance(result, AgentInput)
+    mock_context.store.set.assert_any_call("return_direct_pending", True)
+    calls_to_clear = [
+        call
+        for call in mock_context.store.set.call_args_list
+        if call[0][0] == "current_tool_calls" and call[0][1] == []
+    ]
+    assert len(calls_to_clear) == 0
 
 
 @pytest.mark.asyncio

--- a/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
@@ -1,10 +1,13 @@
 from typing import Any, List
 
 import pytest
+from unittest.mock import AsyncMock, MagicMock
 from llama_index.core.agent.workflow import AgentInput
+from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
 from llama_index.core.agent.workflow.function_agent import FunctionAgent
 from llama_index.core.agent.workflow.multi_agent_workflow import AgentWorkflow
 from llama_index.core.agent.workflow.react_agent import ReActAgent
+from llama_index.core.agent.workflow.workflow_events import AgentOutput, ToolCallResult
 from llama_index.core.llms import (
     ChatMessage,
     ChatResponse,
@@ -13,8 +16,8 @@ from llama_index.core.llms import (
     MessageRole,
     MockLLM,
 )
-from llama_index.core.memory import ChatMemoryBuffer
-from llama_index.core.tools import FunctionTool, ToolSelection
+from llama_index.core.memory import ChatMemoryBuffer, BaseMemory
+from llama_index.core.tools import FunctionTool, ToolSelection, ToolOutput
 from llama_index.core.workflow import (
     Context,
     WorkflowRuntimeError,
@@ -73,6 +76,22 @@ class MockLLM(MockLLM):
         self, response: ChatResponse, **kwargs: Any
     ) -> List[ToolSelection]:
         return response.message.additional_kwargs.get("tool_calls", [])
+
+
+class SimpleAgent(BaseWorkflowAgent):
+    async def take_step(self, ctx, llm_input, tools, memory):
+        return AgentOutput(
+            response=ChatMessage(role="assistant", content="test"),
+            tool_calls=[],
+            raw="test",
+            current_agent_name=self.name,
+        )
+
+    async def handle_tool_call_results(self, ctx, results, memory):
+        pass
+
+    async def finalize(self, ctx, output, memory):
+        return output
 
 
 def add(a: int, b: int) -> int:
@@ -533,3 +552,48 @@ async def test_retry():
     response = await handler
 
     assert "8" in str(response.response)
+
+
+@pytest.mark.asyncio
+async def test_aggregate_tool_results_return_direct_sets_flag():
+    agent = SimpleAgent(name="simple", description="test", tools=[], llm=None)
+    workflow = AgentWorkflow(agents=[agent], root_agent="simple")
+
+    ctx = MagicMock(spec=Context)
+    ctx.store = AsyncMock()
+    ctx.store.get = AsyncMock()
+    ctx.store.set = AsyncMock()
+    ctx.collect_events = MagicMock()
+
+    mock_memory = MagicMock(spec=BaseMemory)
+    mock_memory.aget = AsyncMock(return_value=[])
+
+    tool_output = ToolOutput(
+        content="ok",
+        tool_name="direct_tool",
+        raw_input={},
+        raw_output="ok",
+        is_error=False,
+    )
+    return_direct_tool = ToolCallResult(
+        tool_name="direct_tool",
+        tool_kwargs={},
+        tool_id="tool_123",
+        tool_output=tool_output,
+        return_direct=True,
+    )
+
+    ctx.collect_events.return_value = [return_direct_tool]
+    ctx.store.get.side_effect = lambda key, default=None: {
+        "num_tool_calls": 1,
+        "current_tool_calls": [],
+        "memory": mock_memory,
+        "current_agent_name": "simple",
+        "user_msg_str": "test message",
+        "next_agent": None,
+    }.get(key, default)
+
+    result = await workflow.aggregate_tool_results(ctx, return_direct_tool)
+
+    assert isinstance(result, AgentInput)
+    ctx.store.set.assert_any_call("return_direct_pending", True)


### PR DESCRIPTION
## Summary
- Ensure function agents mark return_direct results without injecting assistant replies
- Add return_direct_pending flag to run one extra LLM pass instead of returning raw tool output
- Document and test new return_direct behavior

## Testing
- `pytest llama-index-core/tests/agent/workflow/test_function_call.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbd0a89fb8832bb4f537eac6a857b2